### PR TITLE
fix(meta): Add description meta tag

### DIFF
--- a/src/ui/Meta.svelte
+++ b/src/ui/Meta.svelte
@@ -26,6 +26,7 @@
 	{#if description}
 		<meta property="og:description" content="{description}" />
 		<meta name="twitter:description" content="{description}" />
+		<meta name="description" content="{description}" />
 	{/if}
 
 	<meta name="twitter:card" content="{twitterType}" />


### PR DESCRIPTION
description meta is being used by Google
search engine to show the page info