### PR TITLE
fix(): fix tsconfig not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"dev": "dotenv vite dev",
 		"preview": "vite preview",
-		"start": "node dist"
+		"start": "node dist",
+		"prepare": "svelte-kit sync"
 	},
 	"type": "module",
 	"keywords": [


### PR DESCRIPTION
```
[WARNING] Cannot find base config file "./.svelte-kit/tsconfig.json" [tsconfig.json]

    tsconfig.json:2:12:
      2 │   "extends": "./.svelte-kit/tsconfig.json",
```